### PR TITLE
fix(function)restored functionality to featured option

### DIFF
--- a/src/components/HeroCard.js
+++ b/src/components/HeroCard.js
@@ -1,8 +1,11 @@
 import { Link } from 'react-router-dom';
+import {useContext} from 'react';
+import {GlobalContext} from '../context/GlobalContext';
 import { GiBatMask } from 'react-icons/gi';
 import { FaStar, FaRegStar } from 'react-icons/fa';
 
 const HeroCard = ({ hero }) => {
+  const {updateFeatured} = useContext(GlobalContext);
   return (
     <div className='card mb-3'>
       {/* header */}
@@ -39,7 +42,7 @@ const HeroCard = ({ hero }) => {
           </Link>
           <a
             href='javascript:void(0)'
-            // onClick={() => updateFeatured(hero.id)}
+            onClick={() => updateFeatured(hero.id)}
             className='card-link'>
             {hero.featured ? <FaStar /> : <FaRegStar />}
           </a>


### PR DESCRIPTION
## Changes
1. imported useContext from react
2. imported GlobalContext
3. added {updateFeatured} = useContext(GlobalContext) to const HeroCard
4. Reimplemented onClick=updateFeatured on line 45.

## Purpose
Heroes weren't being featured when the star icon was clicked.

## Manual Testing
Select any hero and click the star, it should change to an unfilled star for a non-featured hero, & a filled star for a featured hero.
If you click a featured hero on the dashboard page that hero should be removed.

### Closes #010
